### PR TITLE
Fix failing get_org_paths test

### DIFF
--- a/tests/lib/test_organizations.py
+++ b/tests/lib/test_organizations.py
@@ -8,20 +8,14 @@ from lib.organization import (
 
 
 def test_get_org_paths() -> None:
-    org_paths = get_organizations_path(
-        Path("tests/fixtures/with_well_formatted_organizations")
-    )
+    root = Path("tests/fixtures/with_well_formatted_organizations")
+
+    org_paths = get_organizations_path(root)
     assert len(org_paths) == 2
 
-    assert (
-        str(org_paths[0])
-        == "tests/fixtures/with_well_formatted_organizations/test_orga_1/organization.json"  # noqa: E501
-    )
-
-    assert (
-        str(org_paths[1])
-        == "tests/fixtures/with_well_formatted_organizations/test_orga_2/organization.json"  # noqa: E501
-    )
+    org_paths = sorted(path.relative_to(root) for path in org_paths)
+    assert str(org_paths[0]) == "test_orga_1/organization.json"
+    assert str(org_paths[1]) == "test_orga_2/organization.json"
 
 
 def test_get_organizations_list() -> None:


### PR DESCRIPTION
Cleanup #1 

Pour une raison que j'ignore, la CI se met à ne plus recevoir les chemins dans le bon ordre (alors que lors de la review de #1 les tests passaient).

Cette PR les trie avant de les inspecter.