### PR TITLE
Check organizations/ directory within 'make check'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: "Install dependencies"
         run: make install
 
-      - name: "Run code checks"
+      - name: "Run checks"
         run: make check
 
       - name: "Unit tests"

--- a/Makefile
+++ b/Makefile
@@ -19,15 +19,9 @@ format: #- Format code
 	${bin}black ${pysources}
 	${bin}isort ${pysources}
 
-check: #- Check the code
+check: #- Check the code and organizations
 	${bin}black --check ${pysources}
 	${bin}flake8 ${pysources}
 	${bin}mypy ${pysources}
 	${bin}isort --check --diff ${pysources}
-
-check-format: #- Format and check the code
-	make format
-	make check
-	
-check-organizations: #- Validate organizations schema
 	${bin}python -m scripts.check_organizations organizations

--- a/tests/lib/test_organizations.py
+++ b/tests/lib/test_organizations.py
@@ -13,7 +13,6 @@ def test_get_org_paths() -> None:
     org_paths = get_organizations_path(root)
     assert len(org_paths) == 2
 
-    org_paths = sorted(path.relative_to(root) for path in org_paths)
     assert str(org_paths[0]) == "test_orga_1/organization.json"
     assert str(org_paths[1]) == "test_orga_2/organization.json"
 


### PR DESCRIPTION
Actuellement la CI lance `make check`, mais ce script ne lance pas le script dédié `make check-organizations`.

Cette PR regroupe ces 2 parties sous le même `make check`, qui vérifie donc à la fois la qualité du code et la conformité des dossiers d'organisations.