### PR TITLE
Load organizations paths in a deterministic order

### DIFF
--- a/lib/organization.py
+++ b/lib/organization.py
@@ -17,6 +17,10 @@ def get_organizations_path(path: Path) -> List[Path]:
         org_path = orgdir / "organization.json"
         org_paths.append(org_path)
 
+    # Order of iterdir() is not deterministic.
+    # Force it for cross-platform testing purposes.
+    org_paths = sorted(org_paths, key=lambda p: p.relative_to(path))
+
     return org_paths
 
 

--- a/tests/lib/test_organizations.py
+++ b/tests/lib/test_organizations.py
@@ -12,9 +12,14 @@ def test_get_org_paths() -> None:
 
     org_paths = get_organizations_path(root)
     assert len(org_paths) == 2
-
-    assert str(org_paths[0]) == "test_orga_1/organization.json"
-    assert str(org_paths[1]) == "test_orga_2/organization.json"
+    assert (
+        str(org_paths[0])
+        == "tests/fixtures/with_well_formatted_organizations/test_orga_1/organization.json"  # noqa: E501
+    )
+    assert (
+        str(org_paths[1])
+        == "tests/fixtures/with_well_formatted_organizations/test_orga_2/organization.json"  # noqa: E501
+    )
 
 
 def test_get_organizations_list() -> None:


### PR DESCRIPTION
La CI sur #5 échoue car un test unitaire suppose que les organisations sont chargées par ordre alphabétique (ordre d'affichage des dossiers dans VS Code, par exemple), alors que cet ordre peut changer selon la machine.

Cette PR défait en partie #8 qui avait patché un test qui faisait la même hypothèse initialement. (Edit : je me suis emmêlé les pinceaux, une partie de ce changement a été faite dans #10, mais elle était insuffisante.)