### PR TITLE
fix: ci cassée

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,3 @@ check: #- Check the code and organizations
 
 upload: #- Upload organizations
 	${bin}python -m scripts.upload_organizations organizations
-	${bin}python -m scripts.upload_catalog_schema organizations


### PR DESCRIPTION
### Cette PR résoud :

- le script d'upload des schéma de catalogue avait été mis par erreur dans le Makefile alors qu'il n'existe pas encore sur la branche `main`