### PR TITLE
fix: skip catalog checks if catalog does not exists

### DIFF
--- a/scripts/check_catalog_schema.py
+++ b/scripts/check_catalog_schema.py
@@ -17,6 +17,12 @@ from lib.format_text import format_error_message, format_success_message
 def main(directory: Path) -> int:
     code = 0
     for schema_path in get_schema_paths(directory):
+
+        if not schema_path.is_file():
+            # if there is no data schema in the organization directory skip the checks
+            # and continue
+            continue
+
         try:
             schema = Schema(schema_path)
             report = schema.validate()

--- a/tests/scripts/test_check_catalog_schema.py
+++ b/tests/scripts/test_check_catalog_schema.py
@@ -21,9 +21,9 @@ def test_return_1_exit_code_if_all_catalog_schema_are_not_valid_table_schema() -
     assert code == 1
 
 
-def test_return_1_exit_code_if_a_catalog_schema_does_not_exists() -> None:
+def test_return_0_exit_code_if_a_catalog_schema_does_not_exists() -> None:
     code = main(Path("tests/fixtures/with_no_existing_catalog_schema"))  # noqa: E501
-    assert code == 1
+    assert code == 0
 
 
 def test_return_1_exit_code_if_at_least_one_field_is_missing() -> None:


### PR DESCRIPTION
# Cette PR ajoute

- un correctif qui permet de passer la vérification d'un schéma de catalogue ci celui-ci n'existe pa

### Pour tester

- créer un dossier d'organisation avec seulement un fichier organization.json
- NE PAS rajouter de fichier `catalog_schema.json`

Lancer la commande `make check` aucun message de couleur rouge ne devrait s'afficher dans la console
