### PR TITLE
Fix list of fields in common schema

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -16,7 +16,6 @@ COMMON_SCHEMA_FIELD_NAMES = set(
         "couv_geo",
         "url",
         "format",
-        "licence",
-        "producteur_type",
+        "licence"
     ]
 )


### PR DESCRIPTION
Un champ en trop dans liste des champs du [schéma commun](https://github.com/etalab/schema-catalogue-donnees).

Permettra de débloquer la pipeline (https://github.com/etalab/catalogage-donnees-config/actions/runs/3336616172/jobs/5521980648) pour merger #27

Rel : https://github.com/etalab/catalogage-donnees/issues/522