### PR TITLE
fix: remove `producteur_type` from common schema

### DIFF
--- a/lib/constants.py
+++ b/lib/constants.py
@@ -17,6 +17,5 @@ COMMON_SCHEMA_FIELD_NAMES = set(
         "url",
         "format",
         "licence",
-        "producteur_type",
     ]
 )

--- a/tests/lib/test_catalog_schema.py
+++ b/tests/lib/test_catalog_schema.py
@@ -34,7 +34,6 @@ def test_has_no_missing_fields() -> None:
         "url",
         "format",
         "licence",
-        "producteur_type",
     ]
 
     assert get_missing_fields(fields) == set([])
@@ -57,12 +56,11 @@ def test_has_missing_fields() -> None:
         "freq_maj",
         "couv_geo",
         "url",
-        "format",
     ]
 
     missing_fields = get_missing_fields(fields)
     assert len(missing_fields) == 2
-    assert missing_fields == set(["licence", "producteur_type"])
+    assert missing_fields == set(["licence", "format"])
 
 
 def test_has_extra_fields() -> None:

--- a/tests/scripts/test_upload_catalog_schema_and_organization.py
+++ b/tests/scripts/test_upload_catalog_schema_and_organization.py
@@ -40,12 +40,27 @@ def test_upload_new_catalog_schema_and_new_organization(
         "/api/organizations/",
         {"siret": "55566688899991", "name": "test_1"},
     )
+
+    print(request2[2])
     assert request2 == (
         "POST",
         "/api/catalogs/",
         {
             "organization_siret": "55566688899991",
             "extra_fields": [
+                {
+                    "name": "producteur_type",
+                    "title": "Type de producteur",
+                    "hint_text": "Type de l'entité qui produit le jeu de données au sein du Ministère de la Culture.",
+                    "type": "ENUM",
+                    "data": {
+                        "values": [
+                            "1. Administration centrale",
+                            "2. Direction régionale des affaires culturelles",
+                            "3. Service à compétence nationale",
+                        ]
+                    },
+                },
                 {
                     "name": "direction",
                     "title": "Direction",


### PR DESCRIPTION
## Cette PR

Enlève le champs `producteur_type` du schéma commun
